### PR TITLE
Fix/inconsitent error for iin inin compared to in and nin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "light-rule-engine"
-version = "0.3.2"
+version = "0.3.3"
 description = "A simple rule engine"
 authors = ["Biagio Distefano <me@biagiodistefano.io>"]
 readme = "README.md"

--- a/src/rule_engine/rule.py
+++ b/src/rule_engine/rule.py
@@ -71,6 +71,8 @@ def _func(field_value: t.Any, func: t.Callable[[t.Any], bool]) -> bool:  # pragm
 
 
 def _iin(field_value: str | None, condition_value: str | list[str]) -> bool:
+    if field_value is None:
+        return False
     if not isinstance(field_value, str):
         raise ValueError("The value for the `IIN` operator must be a string.")
     if isinstance(condition_value, str):

--- a/src/rule_engine/rule.py
+++ b/src/rule_engine/rule.py
@@ -70,7 +70,7 @@ def _func(field_value: t.Any, func: t.Callable[[t.Any], bool]) -> bool:  # pragm
     raise ValueError("The value for the `FUNC` operator must be a callable.")
 
 
-def _iin(field_value: str, condition_value: str | list[str]) -> bool:
+def _iin(field_value: str | None, condition_value: str | list[str]) -> bool:
     if not isinstance(field_value, str):
         raise ValueError("The value for the `IIN` operator must be a string.")
     if isinstance(condition_value, str):

--- a/src/rule_engine/tests/test_rule_engine.py
+++ b/src/rule_engine/tests/test_rule_engine.py
@@ -231,3 +231,7 @@ def test_iin_value_error(data: dict[str, t.Any], condition_value: t.Any) -> None
     with pytest.raises(ValueError):
         rule = Rule(foo__iin=condition_value)
         evaluate(rule, data)
+
+
+def test_regression_iin_field_not_in_data() -> None:
+    assert not Rule(xyz__iin=["spam"]).evaluate({'foo': 'bar'})

--- a/src/rule_engine/tests/test_rule_engine.py
+++ b/src/rule_engine/tests/test_rule_engine.py
@@ -25,6 +25,7 @@ from rule_engine.rule import OPERATOR_FUNCTIONS, EvaluationResult, Operator, Rul
         (Operator.IIN, "hello", ["world", "foo"], False),
         (Operator.IIN, "hello", "Hello world", True),
         (Operator.ININ, "hello", ["world", "foo"], True),
+        (Operator.IIN, None, "Hello world", False),
         (Operator.ININ, "hello", ["world", "hello"], False),
         (Operator.STARTSWITH, "hello", "he", True),
         (Operator.STARTSWITH, "hello", "lo", False),
@@ -231,7 +232,3 @@ def test_iin_value_error(data: dict[str, t.Any], condition_value: t.Any) -> None
     with pytest.raises(ValueError):
         rule = Rule(foo__iin=condition_value)
         evaluate(rule, data)
-
-
-def test_regression_iin_field_not_in_data() -> None:
-    assert not Rule(xyz__iin=["spam"]).evaluate({'foo': 'bar'})


### PR DESCRIPTION
When using `__in` we get `EvaluationResult`
```python
>>> from rule_engine import Rule, evaluate
>>> Rule(foo__in=["bar"]).evaluate({"foo": "fd"})
EvaluationResult(result=False, children=0)
```
but when we use `__iin` we get a `ValueError`

```python
>>> from rule_engine import Rule
>>> Rule(xyz__iin=["spam"]).evaluate({'foo': 'bar'})
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    Rule(xyz__iin=["spam"]).evaluate({'foo': 'bar'})
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/Users/amc/Documents/code/gitLibs/keyring/rule-engine/src/rule_engine/rule.py", line 286, in evaluate
    child_result = self._evaluate_condition(condition, example)
  File "/Users/amc/Documents/code/gitLibs/keyring/rule-engine/src/rule_engine/rule.py", line 255, in _evaluate_condition
    result = self._evaluate_operator(operator, field_value, condition_value)
  File "/Users/amc/Documents/code/gitLibs/keyring/rule-engine/src/rule_engine/rule.py", line 276, in _evaluate_operator
    return OPERATOR_FUNCTIONS[operator](field_value, condition_value)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/amc/Documents/code/gitLibs/keyring/rule-engine/src/rule_engine/rule.py", line 75, in _iin
    raise ValueError("The value for the `IIN` operator must be a string.")
ValueError: The value for the `IIN` operator must be a string.
```