### PR TITLE
fix: corrects JSON parse error with `NOT_SET` as a value

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "light-rule-engine"
-version = "0.5.0"
+version = "0.5.1"
 description = "A simple rule engine"
 authors = ["Biagio Distefano <me@biagiodistefano.io>"]
 readme = "README.md"

--- a/src/rule_engine/rule.py
+++ b/src/rule_engine/rule.py
@@ -3,6 +3,7 @@ import re
 import typing as t
 from enum import Enum
 from functools import partial
+from json import JSONEncoder
 from uuid import uuid4
 
 
@@ -189,6 +190,7 @@ class EvaluationResult:
 
     def to_json(self, *args: t.Any, **kwargs: t.Any) -> str:
         """Serialize the EvaluationResult to a JSON string."""
+        kwargs["cls"] = kwargs.get("cls", RuleJSONEncoder)
         return json.dumps(self.to_dict(), *args, **kwargs)
 
     def __repr__(self) -> str:  # pragma: no cover
@@ -369,3 +371,13 @@ class Rule:
 
 def evaluate(rule: Rule, example: t.Dict[str, t.Any]) -> EvaluationResult:
     return rule.evaluate(example)
+
+
+class RuleJSONEncoder(JSONEncoder):
+    """Custom JSON encoder that handles NotSetType."""
+
+    def default(self, obj: t.Any) -> t.Any:
+        """Handle NotSetType."""
+        if isinstance(obj, NotSetType):
+            return None
+        return super().default(obj)

--- a/src/rule_engine/tests/test_rule_engine.py
+++ b/src/rule_engine/tests/test_rule_engine.py
@@ -1,8 +1,9 @@
+import json
 import typing as t
 
 import pytest
 
-from rule_engine.rule import OPERATOR_FUNCTIONS, EvaluationResult, Operator, Rule, evaluate
+from rule_engine.rule import NOT_SET, OPERATOR_FUNCTIONS, EvaluationResult, Operator, Rule, evaluate
 
 
 @pytest.mark.parametrize(
@@ -251,3 +252,18 @@ def test_raise_on_not_set() -> None:
     rule = Rule(foo="bar", __raise_on_notset=True)
     with pytest.raises(ValueError):
         rule.evaluate({})
+
+
+def test_regression_not_set_json_serialization() -> None:
+    """Test that NOT_SET is properly serialized to JSON as null."""
+    rule = Rule(test_nin=["example"])
+    result = rule.evaluate({"test": "example"})
+
+    # Test direct JSON serialization
+    json_str = result.to_json()
+    json_data = json.loads(json_str)
+    assert json_data["value"] is None
+
+    # Verify the original evaluation result
+    assert result.value is NOT_SET
+    assert not bool(result)  # Should be False since test="example" is in ["example"]

--- a/src/rule_engine/tests/test_rule_engine.py
+++ b/src/rule_engine/tests/test_rule_engine.py
@@ -3,7 +3,7 @@ import typing as t
 
 import pytest
 
-from rule_engine.rule import NOT_SET, OPERATOR_FUNCTIONS, EvaluationResult, Operator, Rule, evaluate
+from rule_engine.rule import NOT_SET, OPERATOR_FUNCTIONS, EvaluationResult, Operator, Rule, RuleJSONEncoder, evaluate
 
 
 @pytest.mark.parametrize(
@@ -263,7 +263,7 @@ def test_raise_on_not_set() -> None:
 )
 def test_regression_not_set_json_serialization(
     input_data: dict[str, str],
-    expected_value: t.Optional[str],
+    expected_value: str | None,
     expected_result: bool,
 ) -> None:
     """Test that NOT_SET is properly serialized to JSON as null."""
@@ -278,3 +278,15 @@ def test_regression_not_set_json_serialization(
     # Verify the original evaluation result
     assert (result.value is NOT_SET) == (expected_value is None)
     assert bool(result) is expected_result
+
+
+def test_rule_json_encoder() -> None:
+    """Test RuleJSONEncoder handles both NOT_SET and regular objects."""
+    encoder = RuleJSONEncoder()
+
+    # Test NOT_SET encoding
+    assert encoder.default(NOT_SET) is None
+
+    # Test regular object falls back to default behavior
+    with pytest.raises(TypeError):
+        encoder.default(object())


### PR DESCRIPTION
## Issue
When attempting to serialise rule evaluation results containing `NOT_SET` values to JSON, the following error occurs:

```python
>>> rule = Rule(test_nin=["example"])
>>> result = rule.evaluate({"test": "example"})
>>> result.to_json()
TypeError: Object of type NotSetType is not JSON serialisable
```

This breaks JSON serialisation for any rules that check for missing fields or use the `notset` operator.

## Solution
Added a custom `RuleJSONEncoder` that serialises `NOT_SET` values to `null` in JSON:

```python
class RuleJSONEncoder(JSONEncoder):
    def default(self, obj):
        if isinstance(obj, NotSetType):
            return None
        return super().default(obj)
```

Now the serialization works as expected:
```python
>>> result.to_json()
'{"field": "test_nin", "value": null, "operator": "eq", ...}'
```

## Changes
- Added `RuleJSONEncoder` class to handle `NOT_SET` serialisation
- Modified `EvaluationResult.to_json()` to use the custom encoder by default
- Added regression test to verify the fix

## Testing
Added a test case that verifies:
- `NOT_SET` is properly serialised as `null` in JSON
- Original Python evaluation maintains `NOT_SET` value
- Rule evaluation behaviour remains correct

We also add a specific test on the `RuleJsonEncoder` for test coverage.