### PR TITLE
Make `raise_on_notset` default to `True` with environment variable override

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "light-rule-engine"
-version = "0.5.1"
+version = "1.0.0"
 description = "A simple rule engine"
 authors = ["Biagio Distefano <me@biagiodistefano.io>"]
 readme = "README.md"

--- a/src/rule_engine/rule.py
+++ b/src/rule_engine/rule.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 import typing as t
 from enum import Enum
@@ -207,11 +208,13 @@ class Rule:
                 The keys should be field names and the values should be dictionaries
                 with operator names as keys and values as values.
                 - the special key `__id` can be used to set the rule ID
-                - the special key `__raise_on_notset` can be used to raise an exception
-                  if a field is not set in the example data and is to be evaluated.
+                - the special key `__raise_on_notset` can be used to override the default behavior
+                  of raising an exception when a field is not set in the example data
         """
         self._id = self._validate_id(conditions.pop("__id", str(uuid4())))
-        self._raise_on_notset = conditions.pop("__raise_on_notset", False)
+        # Default to True unless explicitly disabled via env var or override in conditions
+        default_raise = os.getenv("RULE_ENGINE_RAISE_ON_NOTSET", "true").lower() in ["true", "1"]
+        self._raise_on_notset = conditions.pop("__raise_on_notset", default_raise)
         self._conditions: list[tuple[_OP, t.Union[dict[str, t.Any], "Rule"]]] = []
         for arg in args:
             if isinstance(arg, Rule):

--- a/src/rule_engine/tests/test_rule_engine.py
+++ b/src/rule_engine/tests/test_rule_engine.py
@@ -237,11 +237,11 @@ def test_iin_value_error(data: dict[str, t.Any], condition_value: t.Any) -> None
 @pytest.mark.parametrize(
     ("data", "rule", "expected_result"),
     [
-        ({}, Rule(whatever__gte=3), False),
-        ({}, Rule(name__iin=["John", "Jane"]), False),
-        ({}, Rule(name__notset=True), True),
-        ({"name": "Frank"}, Rule(name__notset=True), False),
-        ({"name": "Frank"}, Rule(name__notset=False), True),
+        ({}, Rule(whatever__gte=3, __raise_on_notset=False), False),
+        ({}, Rule(name__iin=["John", "Jane"], __raise_on_notset=False), False),
+        ({}, Rule(name__notset=True, __raise_on_notset=False), True),
+        ({"name": "Frank"}, Rule(name__notset=True, __raise_on_notset=False), False),
+        ({"name": "Frank"}, Rule(name__notset=False, __raise_on_notset=False), True),
     ],
 )
 def test_not_set(data: dict[str, t.Any], rule: Rule, expected_result: bool) -> None:
@@ -267,7 +267,7 @@ def test_regression_not_set_json_serialization(
     expected_result: bool,
 ) -> None:
     """Test that NOT_SET is properly serialized to JSON as null."""
-    rule = Rule(field_match__nin=["not-set"])
+    rule = Rule(field_match__nin=["not-set"], __raise_on_notset=False)
     result = rule.evaluate(input_data)
 
     # Test direct JSON serialization

--- a/src/rule_engine/tests/test_rule_engine.py
+++ b/src/rule_engine/tests/test_rule_engine.py
@@ -258,7 +258,7 @@ def test_raise_on_not_set() -> None:
     ("input_data", "expected_value", "expected_result"),
     [
         ({"no-field-match": "not-set"}, None, False),  # NOT_SET case
-        ({"field_match": "is-set"}, "is-set", True),   # Normal case
+        ({"field_match": "is-set"}, "is-set", True),  # Normal case
     ],
 )
 def test_regression_not_set_json_serialization(
@@ -290,3 +290,42 @@ def test_rule_json_encoder() -> None:
     # Test regular object falls back to default behavior
     with pytest.raises(TypeError):
         encoder.default(object())
+
+
+@pytest.mark.parametrize(
+    ("env_value", "init_value", "expected_raise"),
+    [
+        ("true", None, True),  # Default env var behavior
+        ("1", None, True),  # Alternative true value
+        ("false", None, False),
+        ("", None, False),
+        ("invalid", None, False),
+        ("true", False, False),  # Explicit override in init
+        ("false", True, True),  # Explicit override in init
+    ],
+)
+def test_raise_on_notset_behavior_env_var_settings(
+    env_value: str, init_value: bool | None, expected_raise: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that _raise_on_notset respects both environment variable and explicit settings."""
+    monkeypatch.setenv("RULE_ENGINE_RAISE_ON_NOTSET", env_value)
+
+    rule_kwargs = {}
+    if init_value is not None:
+        rule_kwargs["__raise_on_notset"] = init_value
+
+    rule = Rule(foo="bar", **rule_kwargs)
+
+    if expected_raise:
+        with pytest.raises(ValueError, match="Field 'foo' is not set in the example data"):
+            rule.evaluate({})
+    else:
+        result = rule.evaluate({})
+        assert bool(result) is False
+
+
+def test_raise_on_notset_behavior_no_env_var_expected_raise() -> None:
+    """Test that _raise_on_notset respects both environment variable and explicit settings."""
+    rule = Rule(foo="bar")
+    with pytest.raises(ValueError, match="Field 'foo' is not set in the example data"):
+        rule.evaluate({})


### PR DESCRIPTION
This PR changes how the rule engine handles missing fields by making it stricter by default while maintaining flexibility for users who need different behaviour.

## Key changes:
1. Changed `_raise_on_notset` to default to `True` instead of `False`
2. Added environment variable `RULE_ENGINE_RAISE_ON_NOTSET` to globally control this behavior
   - Set to "true" or "1" to enable raising (default)
   - Set to any other value to disable raising
3. Maintained the ability to override per-rule using `__raise_on_notset` parameter
4. Updated tests to:
   - Explicitly set `__raise_on_notset=False` where needed
   - Add comprehensive test coverage for environment variable behavior
   - Verify interaction between env var and per-rule settings

This change makes the behaviour more explicit and safer by default, as it will now alert users when they try to evaluate rules against missing fields rather than silently failing. Users who need the old behavior can either:
- Set `RULE_ENGINE_RAISE_ON_NOTSET=false` globally
- Set `__raise_on_notset=False` on specific rules