### PR TITLE
fix: correcting poetry install

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install poetry
-          poetry install --no-dev
+          poetry install --only main
       - name: Build package
         run: |
           poetry build


### PR DESCRIPTION
`--no-dev` is deprecated, use `--only main` or `--without dev` instead https://python-poetry.org/docs/1.8/cli/#options-2

New version 2 doesn't include it: https://python-poetry.org/docs/1.8/cli/#options-2