### PR TITLE
add raise_on_notset to evaluate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "light-rule-engine"
-version = "1.0.1"
+version = "1.1.0"
 description = "A simple rule engine"
 authors = ["Biagio Distefano <me@biagiodistefano.io>"]
 readme = "README.md"

--- a/src/rule_engine/tests/test_rule_engine.py
+++ b/src/rule_engine/tests/test_rule_engine.py
@@ -254,6 +254,12 @@ def test_raise_on_not_set() -> None:
         rule.evaluate({})
 
 
+def test_raise_on_not_set_evaluate() -> None:
+    rule = Rule(foo="bar", __raise_on_notset=False)
+    with pytest.raises(ValueError):
+        rule.evaluate({}, raise_on_notset=True)
+
+
 @pytest.mark.parametrize(
     ("input_data", "expected_value", "expected_result"),
     [


### PR DESCRIPTION
You can now do:

```
rule.evaluate({}, raise_on_notset=True)
```

or

```
evaluate(rule, data, raise_on_notset=True)
```

Which will override the Rule behaviour and/or the env var `RULE_ENGINE_RAISE_ON_NOTSET`